### PR TITLE
getMac via regex for all OS

### DIFF
--- a/hostmac.py
+++ b/hostmac.py
@@ -83,24 +83,16 @@ def getMac(ip):
         return arp
     if os.name == 'nt':  # Windows
         arpResult = subprocArp("arp -a %s" % ip)
-        try:
-            if arpResult[0].startswith("No ARP"):
-                item = "MAC not found, No ARP entry"
-            if arpResult[0].split("\n")[1].startswith("Interface:"):
-                item = arpResult[0].split("\n")[-2]
-                item = item.split()[1]
-                item = item.replace("-", ":").upper()
-            if arpResult[1] == None:
-                item = "ARP bad argument"
-        except IndexError:
-            if arpResult[1].startswith("ARP: bad argument"):
-                item = "ARP bad argument"
-        except:
-            item = "Gen. except error in getMac()"
-    if os.name == 'posix': # *nux or OSX
+        find_mac = re.search(r'[\b\s]*(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))[\b\s]*',
+                             str(arpResult[0].upper()))
+        if find_mac:
+            item = find_mac.group(1).replace("-", ":")
+        else:
+            item = 'No MAC addr. found'
+    if os.name == 'posix': # *nix or OSX
         arpResult = subprocArp("arp -a | grep -w %s" % ip)
-        find_mac = re.search(r'\s(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))?\s',
-                             arpResult[0].upper())
+        find_mac = re.search(r'[\b\s]*(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))[\b\s]*',
+                             str(arpResult[0].upper()))
         if find_mac:
             item = find_mac.group(1)
         else:

--- a/hostmac.py
+++ b/hostmac.py
@@ -83,20 +83,14 @@ def getMac(ip):
         return arp
     if os.name == 'nt':  # Windows
         arpResult = subprocArp("arp -a %s" % ip)
-        find_mac = re.search(r'[\b\s]*(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))[\b\s]*',
-                             str(arpResult[0].upper()))
-        if find_mac:
-            item = find_mac.group(1).replace("-", ":")
-        else:
-            item = 'No MAC addr. found'
-    if os.name == 'posix': # *nix or OSX
+    if os.name == 'posix':  # *nix or OSX
         arpResult = subprocArp("arp -a | grep -w %s" % ip)
-        find_mac = re.search(r'[\b\s]*(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))[\b\s]*',
-                             str(arpResult[0].upper()))
-        if find_mac:
-            item = find_mac.group(1)
-        else:
-            item = 'No MAC addr. found'
+    find_mac = re.search(r'[\b\s]*(([0-9A-F]{2}[:-]){5}([0-9A-F]{2}))[\b\s]*',
+                         str(arpResult[0].upper()))
+    if find_mac:
+        item = re.sub('-', ':', find_mac.group(1))
+    else:
+        item = 'No MAC addr. found'
     return item
 
 def getOne(ip):


### PR DESCRIPTION
There is currently no open issue around this function, but I wanted to share this branch.

This PR contains 2 commits:
https://github.com/bcambl/HostMAC/commit/63b61193657abeda1750b279c516c20886e9dece 
Swap out string manipulation with a regular expression.

https://github.com/bcambl/HostMAC/commit/6c9b93a23742dbee5e142118abbd66fd898fec57 
OS check for arp command, then find MAC via regex for both windows and *nix.

This PR simplifies 21 lines down to 7 lines under the following  assumptions: 
- The following output is not needed:
  `item = "MAC not found, No ARP entry"`
  `item = "ARP bad argument"`
  `item = "Gen. except error in getMac()"`
- OSX support - untested in OSX
