### PR TITLE
argparse integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ When run, user has two available options:
 
 * Results are written to ```/YYYY-MM-DD_output/ip.csv```
 
+### Help
+```
+$ ./hostmac.py -h
+```
+
 ___
 
 ### Tested in:
@@ -21,10 +26,10 @@ OS | Python Version
 --- | ---
 Fedora 21 | 2.7.8
 Fedora 21 | 3.4.1
-CentOS 6.6 | 2.6.6
 CentoOS 7.0 | 2.7.5
 Ubuntu 14.10 | 2.7.8
-Windows 8 | 2.7.9 
+Windows 8 | 2.7.9
+Windows 8 | 3.4.3
 Windows 7 | 2.7.2
 Ubuntu 14.04.2 LTS | 2.7.6
 OSX 10.10.2 | 2.7.6


### PR DESCRIPTION
- addresses issue #38 - allow custom ip range with arguments
- addresses issue #20 - add optional output with '-csv' argument
- Update README.md
  
  I also added a clean exit on keyboard interrupt (^C)

Full cli help output:

```
$ ./hostmac.py -h
usage: hostmac.py [-h] [-csv] [-ip IP] [-all] [-start START] [-end END]

HostMAC

optional arguments:
  -h, --help    show this help message and exit
  -csv          log output to csv
  -ip IP        specify ip, default: current ip
  -all          check range 1-254
  -start START  start of range
  -end END      end of range
```

Discussion points:
- stdout only by default. This seems to be default behavior with most scripts.
- drop python < 2.7 support and test only 2.7.x and 3.x.x
- osx testing

Let me know what you think.
